### PR TITLE
Add unix domain socket support

### DIFF
--- a/src/MQTTClient.jl
+++ b/src/MQTTClient.jl
@@ -2,7 +2,7 @@ module MQTTClient
 
 using Distributed: Future, RemoteChannel
 using Dagger
-using Sockets: TCPSocket
+using Sockets: TCPSocket, PipeServer
 import Sockets: connect
 using Random: randstring
 import Base: ReentrantLock, lock, unlock, convert
@@ -17,6 +17,8 @@ include("interface.jl")
 export
     Client,
     MQTTConnection,
+    TCPConnection,
+    UDSConnection,
     User,
     QOS_0,
     QOS_1,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,6 +3,9 @@
 
 Create a new `Client` object with the specified `ping_timeout` (optional).
 
+# Arguments
+- `path::AbstractString`: The path to the unix domain socket created by the broker on the filesystem
+
 # Keyword Arguments
 - `ping_timeout::UInt64=60`: The number of seconds to wait for a ping response before disconnecting. Default is 60.
 
@@ -10,12 +13,14 @@ Create a new `Client` object with the specified `ping_timeout` (optional).
 ```julia
 client = MQTTConnection()
 client = MQTTConnection(ping_timeout=30)
+client = MQTTConnection("/tmp/mqtt/mqtt.sock")
 ```
 """
 MQTTConnection(;ping_timeout=UInt64(60)) = Client(ping_timeout)
+MQTTConnection(path::AbstractString) = Client(path)
 
 """
-    connect_async(client::Client, host::AbstractString, port::Integer=1883;
+    connect_async(client::Client, conn::AbstractConnection;
        keep_alive::UInt16=0x0000,
        client_id::String=randstring(8),
        user::User=User("", ""),
@@ -32,7 +37,7 @@ Returns a `Future` object that contains a session_present bit from the broker on
 - `will::Message=Message(false, 0x00, false, "", Array{UInt8}())`: The MQTT will to send to all other clients when this client disconnects.  
 - `clean_session::Bool=true`: Flag to resume a session with the broker if present.
 """
-function connect_async(client::Client, host::AbstractString, port::Integer=1883;
+function connect_async(client::Client, conn::AbstractConnection;
                        keep_alive::Int64=10,
                        client_id::String=randstring(8),
                        user::User=User("", ""),
@@ -45,7 +50,15 @@ function connect_async(client::Client, host::AbstractString, port::Integer=1883;
     catch
         error("Could not convert keep_alive to UInt16")
     end
-    client.socket = connect(host, port)
+
+    if conn.type == UDS
+        # Sockets.jl will choose unix socket and return PipeServer()
+        client.socket = connect(conn.path)
+    else
+        # Sockets.jl will choose tcp socket and return TCPSocket()
+        client.socket = connect(conn.host, conn.port)
+    end
+
     @debug "connect to host"
     @dispatch write_loop(client)
     @dispatch read_loop(client)
@@ -60,7 +73,7 @@ function connect_async(client::Client, host::AbstractString, port::Integer=1883;
     #TODO reset client on clean_session = true
 
     protocol_name = "MQTT"
-    protocol_level = 0x04
+    protocol_level = 0x04 # v3.1.1
     connect_flags = 0x02 # clean session
 
     @debug "set protocol"
@@ -101,7 +114,7 @@ function connect_async(client::Client, host::AbstractString, port::Integer=1883;
 end
 
 """
-    connect(client::Client, host::AbstractString, port::Integer=1883;
+    connect(client::Client, conn::AbstractConnection;
         keep_alive::UInt16=0x0000,
         client_id::String=randstring(8),
         user::User=User("", ""),
@@ -118,12 +131,13 @@ Waits until the connect is done. Returns the session_present bit from the broker
 - `will::Message=Message(false, 0x00, false, "", Array{UInt8}())`: The MQTT will to send to all other clients when this client disconnects.  
 - `clean_session::Bool=true`: Flag to resume a session with the broker if present.
 """
-connect(client::Client, host::AbstractString, port::Integer=1883;
+
+connect(client::Client, conn::AbstractConnection;
         keep_alive::Int64=0,
         client_id::String=randstring(8),
         user::User=User("", ""),
         will::Message=Message(false, 0x00, false, "", UInt8[]),
-        clean_session::Bool=true) = resolve(connect_async(client, host, port, keep_alive=keep_alive, client_id=client_id, user=user, will=will, clean_session=clean_session))
+        clean_session::Bool=true) = resolve(connect_async(client, conn, keep_alive=keep_alive, client_id=client_id, user=user, will=will, clean_session=clean_session))
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,11 @@ using MQTTClient
 using Distributed, Random
 
 import MQTTClient: topic_wildcard_len_check, filter_wildcard_len_check, MQTTException
-import Sockets: TCPSocket, connect
+import Sockets: TCPSocket, PipeServer, connect
 
 @testset verbose=true "client tests" begin
 include("unittest.client.jl")
+include("unittest.uds_client.jl")
 end
 @testset verbose=true "utils tests" begin
 include("unittest.utils.jl")
@@ -16,6 +17,13 @@ end
 ## Needs to have internet connection to run
 if !haskey(ENV, "GITHUB_ACTION")
     include("smoke.jl")
+end
+
+## Needs to have a broker listening on /tmp/mqtt/mqtt.sock
+# The broker needs to be configured for anonymous access and to 
+# accept clients which have a max_keepalive = 0
+if haskey(ENV, "UDS_TEST") && ENV["UDS_TEST"] == "true"
+    include("uds_smoke.jl")
 end
 ## !TODO: Fix packet tests for full unit testing
 # include("mocksocket.jl")

--- a/test/unittest.uds_client.jl
+++ b/test/unittest.uds_client.jl
@@ -1,0 +1,216 @@
+function on_msg(t,p)
+    (t,p)
+end
+
+@testset verbose = true "MQTT UDS Client Instantiation" begin
+
+    @testset "UDS Client" begin
+        path = "/tmp/mqtt.sock"
+        c = MQTTConnection(path)
+        @test c.on_msg isa Dict
+        @test c.keep_alive == 0x0000
+        @test c.last_id == 0x0000
+        @test isempty(c.in_flight)
+        @test c.write_packets isa AbstractChannel
+        @test c.socket isa PipeServer
+        @test c.socket_lock isa ReentrantLock
+        @test c.ping_timeout == 60
+        @test c.ping_outstanding[] == 0
+    end
+end
+
+@testset verbose = true "MQTT UDS Client functionality" begin
+
+    path = "/tmp/mqtt/mqtt.sock"
+    
+    @testset "MQTT subscribe async" begin
+        c = MQTTConnection(path)
+        fut = MQTTClient.subscribe_async(c, "test-topic/#", ((p) -> p), qos=MQTTClient.QOS_2)
+        @test fut isa Distributed.Future
+    end
+
+    @testset "MQTT publish async" begin
+        c = MQTTConnection(path)
+        fut = MQTTClient.publish_async(c, "test-topic/mqtt_jl", "test message")
+        @test fut isa Distributed.Future
+    end
+
+    @testset "unsubscribe_async" begin
+        # Create a mock client object
+        client = MQTTConnection(path)
+
+        client.on_msg["topic1"] = ((p) -> p)
+
+        # Set the packet ID
+        id = 1
+        client.last_id = id
+
+        # Call the unsubscribe_async function with a single topic
+        future = unsubscribe_async(client, "topic1")
+
+        # Check that the in_flight dictionary was updated correctly
+        @test client.in_flight[0x0002] == future
+
+        # Check that the write_packet function was called with the correct arguments
+        p = take!(client.write_packets)
+        @test p == MQTTClient.Packet(MQTTClient.UNSUBSCRIBE  | 0x02, (0x0002, "topic1"))
+
+
+        client.on_msg["topic1"] = ((p) -> p)
+        client.on_msg["topic2"] = ((p) -> p)
+        client.on_msg["topic3"] = ((p) -> p)
+        # Call the unsubscribe_async function with multiple topics
+        future = unsubscribe_async(client, "topic1", "topic2", "topic3")
+
+        # Check that the in_flight dictionary was updated correctly
+        @test client.in_flight[0x0003] == future
+
+        # Check that the write_packet function was called with the correct arguments
+        p = take!(client.write_packets)
+        @test p == MQTTClient.Packet(MQTTClient.UNSUBSCRIBE  | 0x02, (0x0003, "topic1", "topic2", "topic3"))
+    end
+end
+
+@testset verbose=true "handlers" begin
+    
+    path = "/tmp/mqtt/mqtt.sock"
+    
+    @testset "handle_connack" begin
+        c = MQTTConnection(path)
+        c.in_flight[0x0000] = Future()
+
+        # Test successful connection
+        io = IOBuffer(UInt8[0x00, 0x00])
+        future = MQTTClient.handle_connack(c, io, 0x00, 0x00)
+        @test fetch(future) == 0x00
+
+        # Test unsuccessful connection
+        io = IOBuffer(UInt8[0x01, 0x01])
+        c.in_flight[0x0000] = Future()
+        future = MQTTClient.handle_connack(c, io, 0x00, 0x00)
+        @test fetch(future) isa MQTTException
+
+        # Test unsuccessful connection
+        io = IOBuffer(UInt8[0x01, 0x01])
+        @test_throws ErrorException MQTTClient.handle_connack(c, io, 0x00, 0x00)
+    end
+
+    @testset "handle_publish" begin
+        c = MQTTConnection(path)
+        ch = Channel()
+        c.on_msg["test1"] = (p) -> put!(ch, p == "payload1")
+        c.on_msg["test1"] = (p) -> put!(ch, p == "payload2")
+        c.on_msg["test1"] = (p) -> put!(ch, p == "payload3")
+
+        # Test QoS 0
+        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x31])
+        MQTTClient.handle_publish(c, io, 0x00, 0x00)
+
+        # Test QoS 1
+        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x32])
+        MQTTClient.handle_publish(c, io, 0x00, 0x02)
+
+        # Test QoS 2
+        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x33])
+        MQTTClient.handle_publish(c, io, 0x00, 0x04)
+
+        while !isempty(ch)
+            @test take!(ch)
+        end
+    end
+
+    @testset "handle_ack" begin
+        c = MQTTConnection(path)
+        c.in_flight[0x0001] = Future()
+
+        # Test successful ack
+        io = IOBuffer(UInt8[0x00, 0x01])
+        MQTTClient.handle_ack(c, io, 0x00, 0x00)
+        @test !haskey(c.in_flight, 0x0001)
+    end
+
+    @testset "handle_pubrec" begin
+        c = MQTTConnection(path)
+        s = IOBuffer()
+
+        # Set the cmd and flags values
+        cmd = 0x50
+        flags = 0x02
+
+        # Write the packet ID to the IO object
+        write(s, UInt16(3))
+        seekstart(s)
+
+        # Call the handle_pubrec function
+        MQTTClient.handle_pubrec(c, s, cmd, flags)
+        p = take!(c.write_packets)
+        #!TODO: Figure out why the id changes
+        @test p == MQTTClient.Packet(MQTTClient.PUBREL  | 0x02, (0x0300,))
+    end
+
+    @testset "handle_pubrel" begin
+        c = MQTTConnection(path)
+        s = IOBuffer()
+
+        # Set the cmd and flags values
+        cmd = 0x62
+        flags = 0x02
+
+        # Write the packet ID to the IO object
+        write(s, UInt16(1))
+        seekstart(s)
+
+        # Call the handle_pubrel function
+        MQTTClient.handle_pubrel(c, s, cmd, flags)
+        p = take!(c.write_packets)
+        @test p == MQTTClient.Packet(MQTTClient.PUBCOMP, (0x0100,))
+    end
+
+    @testset "handle_suback" begin
+        c = MQTTConnection(path)
+        s = IOBuffer()
+
+        # Set the cmd and flags values
+        cmd = 0x90
+        flags = 0x00
+
+        # Write the packet ID and return code to the IO object
+        write(s, UInt16(1))
+        write(s, UInt8(0x00))
+        seekstart(s)
+
+        c.in_flight[0x0100] = Future()
+
+        # Call the handle_suback function
+        MQTTClient.handle_suback(c, s, cmd, flags)
+
+        # Check that the in_flight dictionary was updated correctly
+        future = c.in_flight[0x0100]
+        @test fetch(future) == UInt8[0x01, 0x00, 0x00]
+    end
+
+    @testset "handle_pingresp" begin
+        c = MQTTConnection(path)
+        s = IOBuffer()
+
+        # Set the cmd and flags values
+        cmd = 0xD0
+        flags = 0x00
+
+        # Set the ping_outstanding value to 0x1
+        c.ping_outstanding[] = 0x1
+
+        # Call the handle_pingresp function
+        MQTTClient.handle_pingresp(c, s, cmd, flags)
+
+        # Check that the ping_outstanding value was updated correctly
+        @test c.ping_outstanding[] == 0x0
+
+        # Set the ping_outstanding value to 0x0 and call the handle_pingresp function again
+        c.ping_outstanding[] = 0x0
+        MQTTClient.handle_pingresp(c, s, cmd, flags)
+        p = take!(c.write_packets)
+        @test p == MQTTClient.Packet(MQTTClient.DISCONNECT, ())
+    end
+
+end


### PR DESCRIPTION
I've added some support for unix sockets to be able to send MQTT messages running on the same machine as the broker without needing to use the network. There is a sandbox I've been using here [mqttclientjl-sandbox](https://github.com/lgflorentino/mqttclientjl-sandbox ) to smoke test with a docker container running a mosquitto broker. Let me know if need any further changes