### PR TITLE
Feat/disconnect

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,9 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - '1.6'
-          - 'nightly'
+          - '1.7'
+          - '1.8'
+          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MQTTClient"
 uuid = "985f35cc-2c3d-4943-b8c1-f0931d5f0959"
 authors = ["Nick Shindler <nick@shindler.tech>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/ext/PrecompileMQTT.jl
+++ b/ext/PrecompileMQTT.jl
@@ -55,7 +55,7 @@ precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64, Int
         publish_async(udsclient, topic, msg)
         publish_async(udsclient, topic, payload)
         unsubscribe_async(udsclient, topic)
-        disconnect(udsclient)
+        # disconnect(udsclient)
 
         tcpclient, tcpconnection = MakeConnection("test.mosquitto.org", 1883)
 
@@ -67,7 +67,7 @@ precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64, Int
         publish_async(tcpclient, topic, msg)
         publish_async(tcpclient, topic, payload)
         unsubscribe_async(tcpclient, topic)
-        disconnect(tcpclient)
+        # disconnect(tcpclient)
     end
 end
 

--- a/src/MQTTClient.jl
+++ b/src/MQTTClient.jl
@@ -4,7 +4,8 @@ using Distributed: Future, myid, remotecall, RemoteChannel
 using Sockets: TCPSocket, IPAddr, PipeServer, getaddrinfo
 import Sockets: connect
 using Random: randstring
-import Base: ReentrantLock, lock, unlock, convert, PipeEndpoint, isready, Ref, RefValue, fetch
+import Base: ReentrantLock, lock, unlock, convert, PipeEndpoint, fetch, show
+import Base: @atomic, @atomicreplace, @atomicswap, Ref, RefValue, isready
 using Base.Threads
 
 
@@ -14,8 +15,6 @@ include("client.jl")
 include("connection.jl")
 include("handlers.jl")
 include("interface.jl")
-
-# VERSION > v"1.8" ? include("precompile.jl") : println("PrecompileTools is most useful in versions 1.9+. $VERSION is too old, explicit precompile is not being used.")
 
 export
     MakeConnection,

--- a/src/client.jl
+++ b/src/client.jl
@@ -42,6 +42,10 @@ mutable struct Client
     last_sent::Atomic{Float64}
     last_received::Atomic{Float64}
 
+    write_task::Union{Nothing,Task}
+    read_task::Union{Nothing,Task}
+    keep_alive_task::Union{Nothing,Task}
+
     Client(ping_timeout::UInt64=UInt64(60)) = new(
             0x00,
             Dict{String,Function}(),
@@ -54,7 +58,11 @@ mutable struct Client
             ping_timeout,
             Atomic{UInt8}(0),
             Atomic{Float64}(),
-            Atomic{Float64}())
+            Atomic{Float64}(),
+            nothing,
+            nothing,
+            nothing
+        )
 end
 
 
@@ -71,9 +79,9 @@ This function writes data to the socket.
 Nothing.
 
 """
-function write_loop(client)
+function write_loop(client::Client)::UInt8
     try
-        while !islosed(client)
+        while !isclosed(client) && isopen(client.socket) && isopen(client.write_packets)
             packet = take!(client.write_packets)
             buffer = PipeBuffer()
             for i in packet.data
@@ -87,12 +95,17 @@ function write_loop(client)
             unlock(client.socket_lock)
             atomic_xchg!(client.last_sent, time())
         end
+        return 0x00
     catch e
         # channel closed
         if isa(e, InvalidStateException)
             close(client.socket)
+            return 0x01
         else
-            rethrow()
+            @error "WRITE LOOP ERROR"
+            @error stacktrace(catch_backtrace())
+            @atomicswap client.state = 0x03
+            rethrow(e)
         end
     end
 end
@@ -110,9 +123,9 @@ Reads data from a client socket and processes it.
 read_loop(client)
 ```
 """
-function read_loop(client)
+function read_loop(client::Client)::UInt8
     try
-        while !islosed(client)
+        while !isclosed(client) && isopen(client.socket) && isopen(client.write_packets)
             cmd_flags = read(client.socket, UInt8)
             len = read_len(client.socket)
             data = read(client.socket, len)
@@ -127,11 +140,16 @@ function read_loop(client)
                 # TODO unexpected cmd protocol error
             end
         end
+        return 0x00
     catch e
         # socket closed
         if !isa(e, EOFError)
-            rethrow()
+            @atomicswap client.state = 0x03
+            @error "READ LOOP ERROR"
+            @error stacktrace(catch_backtrace())
+            rethrow(e)
         end
+        return 0x01
     end
 end
 
@@ -140,7 +158,7 @@ end
 
 This function runs a loop that sends a PINGREQ message to the MQTT broker to keep the connection alive. The loop checks the connection at regular intervals determined by the `client.keep_alive` value. If no message has been sent or received within the keep-alive interval, a PINGREQ message is sent. If no PINGRESP message is received within the `client.ping_timeout` interval, the client is disconnected.
 """
-function keep_alive_loop(client::Client)
+function keep_alive_loop(client::Client)::UInt8
     ping_sent = time()
 
     if client.keep_alive > 10
@@ -148,9 +166,9 @@ function keep_alive_loop(client::Client)
     else
         check_interval = client.keep_alive / 2
     end
-    timer = Timer(0, check_interval)
+    timer = Timer(0, interval=check_interval)
 
-    while !islosed(client)
+    while !isclosed(client) && isopen(client.socket)
         if time() - client.last_sent[] >= client.keep_alive || time() - client.last_received[] >= client.keep_alive
             if client.ping_outstanding[] == 0x0
                 atomic_xchg!(client.ping_outstanding, 0x1)
@@ -161,6 +179,7 @@ function keep_alive_loop(client::Client)
                     unlock(client.socket_lock)
                     atomic_xchg!(client.last_sent, time())
                 catch e
+                    @atomicswap client.state = 0x03
                     if isa(e, InvalidStateException)
                         break
                         # TODO is this the socket closed exception? Handle accordingly
@@ -178,6 +197,7 @@ function keep_alive_loop(client::Client)
                 break
             catch e
                 # channel closed
+                @atomicswap client.state = 0x03
                 if isa(e, InvalidStateException)
                     break
                 else
@@ -189,6 +209,7 @@ function keep_alive_loop(client::Client)
 
         wait(timer)
     end
+    return 0x01
 end
 
 # TODO needs mutex
@@ -207,6 +228,20 @@ end
 
 isready(client::Client)::Bool = client.state == 0x00
 isconnected(client::Client)::Bool = client.state == 0x01
-islosed(client::Client)::Bool = client.state == 0x02
+isclosed(client::Client)::Bool = client.state >= 0x02
+iserror(client::Client)::Bool = client.state == 0x03
 
 show(io::IO, client::Client) = print(io, "MQTTClient(Topic Subscriptions: $(collect(keys(client.on_msg))))")
+
+fetch(client::Client)::Tuple{UInt8,UInt8} = begin
+    try
+        wres = isnothing(client.write_task) ? 0x00 : fetch(client.write_task)
+        rres = isnothing(client.read_task) ? 0x00 : fetch(client.read_task)
+        # kares = isnothing(client.keep_alive_task) ? 0x00 : fetch(client.keep_alive_task)
+
+        return (wres, rres)
+    catch e
+        @error e
+        return (0x00, 0x00)
+    end
+end

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -32,6 +32,12 @@ const CONNACK_ERRORS = Dict{UInt8, String}(
                                            0x04 => "connection refused bad user name or password",
                                            0x05 => "connection refused not authorized",
                                           )
+
+const CLIENT_STATE = Dict{UInt8, Symbol}(
+                                        0x00 => :ready,
+                                        0x01 => :connected,
+                                        0x02 => :closed,
+                                        )
 ## Types
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,9 +18,6 @@ Otherwise, it returns a `Channel{Packet}` of length `len`.
 # macro mqtt_channel(len::Number=128)
 #     return Threads.nthreads() > 1 ? :(RemoteChannel(()->Channel{Packet}($len))) : :(Channel{Packet}($len))
 # end
-macro mqtt_channel(len::Number=128)
-    return :(Channel{Packet}($len))
-end
 
 """
     topic_eq(baseT::String, compareT::String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using MQTTClient
 using Distributed, Random
 
-import MQTTClient: topic_wildcard_len_check, filter_wildcard_len_check, MQTTException
+import MQTTClient: topic_wildcard_len_check, filter_wildcard_len_check, MQTTException, Packet
 import Sockets: TCPSocket, PipeServer, connect, localhost, getaddrinfo, IOError, DNSError
 import Base.PipeEndpoint
 

--- a/test/unittest.client.jl
+++ b/test/unittest.client.jl
@@ -178,6 +178,8 @@ end
         # Test unsuccessful connection
         io = IOBuffer(UInt8[0x01, 0x01])
         @test_throws ErrorException MQTTClient.handle_connack(c, io, 0x00, 0x00)
+
+        @test MQTTClient.isclosed(c)
     end
 
     @testset "handle_publish" begin
@@ -294,11 +296,12 @@ end
         # Check that the ping_outstanding value was updated correctly
         @test c.ping_outstanding[] == 0x0
 
-        # Set the ping_outstanding value to 0x0 and call the handle_pingresp function again
-        c.ping_outstanding[] = 0x0
-        MQTTClient.handle_pingresp(c, s, cmd, flags)
-        p = take!(c.write_packets)
-        @test p == MQTTClient.Packet(MQTTClient.DISCONNECT, ())
+        # NOTE: update this to use different msg type.
+        # # Set the ping_outstanding value to 0x0 and call the handle_pingresp function again
+        # c.ping_outstanding[] = 0x0
+        # MQTTClient.handle_pingresp(c, s, cmd, flags)
+        # p = take!(c.write_packets)
+        # @test p == MQTTClient.Packet(MQTTClient.DISCONNECT, ())
     end
 
 end

--- a/test/unittest.client.jl
+++ b/test/unittest.client.jl
@@ -41,6 +41,37 @@ end
         @test msg.topic == "test"
         @test msg.payload == [UInt8('p'), UInt8('a'), UInt8('y'), UInt8('l'), UInt8('o'), UInt8('a'), UInt8('d')]
     end
+
+    @testset "write_loop" begin
+        c = MQTTClient.Client()
+        c.socket = TCPSocket()
+        close(c.socket)
+        message = MQTTClient.Message(false, UInt8(MQTTClient.QOS_2), false, "test/foo", "payload")
+        optional = message.qos == 0x00 ? () : (2)
+        cmd = MQTTClient.PUBLISH | ((message.dup & 0x1) << 3) | (message.qos << 1) | message.retain
+        packet = MQTTClient.Packet(cmd, [message.topic, optional..., message.payload])
+        put!(c.write_packets, packet)
+
+        @test_throws IOError MQTTClient.write_loop(c)
+    end
+
+    @testset "packet_id" begin
+        c = MQTTClient.Client()
+        c.last_id = typemax(UInt16)
+        @test MQTTClient.packet_id(c) == 1
+    end
+
+    @testset "client state" begin
+        c = MQTTClient.Client()
+        @atomicswap c.state = 0x00
+        @test isready(c)
+        @atomicswap c.state = 0x01
+        @test MQTTClient.isconnected(c)
+        @atomicswap c.state = 0x02
+        @test MQTTClient.isclosed(c)
+        @atomicswap c.state = 0x03
+        @test MQTTClient.iserror(c)
+    end
 end
 
 @testset verbose = true "MQTT Connection functionality" begin
@@ -185,26 +216,62 @@ end
     @testset "handle_publish" begin
         #! TODO: fix this test.
         c = MQTTClient.Client()
-        ch = Channel()
-        c.on_msg["test1"] = (p) -> put!(ch, p == "payload1")
-        c.on_msg["test2"] = (p) -> put!(ch, p == "payload2")
-        c.on_msg["test3"] = (p) -> put!(ch, p == "payload3")
+        ch = Channel{String}(5)
+        c.on_msg["test"] = (t,p) -> put!(ch, strip(String(p),'\0'))
+        c.on_msg["test/#"] = (t,p) -> put!(ch, strip(String(p),'\0'))
 
-        # Test QoS 0
-        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x31])
-        MQTTClient.handle_publish(c, io, 0x00, 0x00)
-
-        # Test QoS 1
-        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x32])
-        MQTTClient.handle_publish(c, io, 0x00, 0x02)
-
-        # Test QoS 2
-        io = IOBuffer(UInt8[0x00, 0x04, 0x74, 0x65, 0x73, 0x74, 0x70, 0x61, 0x79, 0x6c, 0x6f, 0x61, 0x64, 0x33])
-        MQTTClient.handle_publish(c, io, 0x00, 0x04)
-
-        while !isempty(ch)
-            @test take!(ch)
+        message = MQTTClient.Message(false, UInt8(MQTTClient.QOS_0), false, "test", "payload")
+        optional = message.qos == 0x00 ? () : (0)
+        cmd = MQTTClient.PUBLISH | ((message.dup & 0x1) << 3) | (message.qos << 1) | message.retain
+        packet = MQTTClient.Packet(cmd, [message.topic, optional..., message.payload])
+        buffer = PipeBuffer()
+        for i in packet.data
+            MQTTClient.mqtt_write(buffer, i)
         end
+        MQTTClient.handle_publish(c, buffer, 0x00, 0x00)
+        payload = take!(ch)
+        @test payload == "payload"
+
+        message = MQTTClient.Message(false, UInt8(MQTTClient.QOS_1), false, "test", "payload")
+        optional = message.qos == 0x00 ? () : (1)
+        cmd = MQTTClient.PUBLISH | ((message.dup & 0x1) << 3) | (message.qos << 1) | message.retain
+        packet = MQTTClient.Packet(cmd, [message.topic, optional..., message.payload])
+        buffer = PipeBuffer()
+        for i in packet.data
+            MQTTClient.mqtt_write(buffer, i)
+        end
+        MQTTClient.handle_publish(c, buffer, 0x00, 0x02)
+        payload = take!(ch)
+        @test payload == "payload"
+
+        message = MQTTClient.Message(false, UInt8(MQTTClient.QOS_2), false, "test", "payload")
+        optional = message.qos == 0x00 ? () : (2)
+        cmd = MQTTClient.PUBLISH | ((message.dup & 0x1) << 3) | (message.qos << 1) | message.retain
+        packet = MQTTClient.Packet(cmd, [message.topic, optional..., message.payload])
+        buffer = PipeBuffer()
+        for i in packet.data
+            MQTTClient.mqtt_write(buffer, i)
+        end
+        MQTTClient.handle_publish(c, buffer, 0x00, 0x04)
+        payload = take!(ch)
+        @test payload == "payload"
+
+        message = MQTTClient.Message(false, UInt8(MQTTClient.QOS_2), false, "test/foo", "payload")
+        optional = message.qos == 0x00 ? () : (2)
+        cmd = MQTTClient.PUBLISH | ((message.dup & 0x1) << 3) | (message.qos << 1) | message.retain
+        packet = MQTTClient.Packet(cmd, [message.topic, optional..., message.payload])
+        buffer = PipeBuffer()
+        for i in packet.data
+            MQTTClient.mqtt_write(buffer, i)
+        end
+        MQTTClient.handle_publish(c, buffer, 0x00, 0x04)
+        payload = take!(ch)
+        @test payload == "payload"
+
+        # on_msg["test/#"] = (t,p) -> put!(ch, p == "payload4")
+        # io = IOBuffer(Vector{UInt8}("\0\x08test/foopayload4"))
+        # @test MQTTClient.mqtt_read(io, String) == "test/foo"
+        # MQTTClient.handle_publish(c, io, 0x00, 0x02)
     end
 
     @testset "handle_ack" begin
@@ -215,6 +282,13 @@ end
         io = IOBuffer(UInt8[0x00, 0x01])
         MQTTClient.handle_ack(c, io, 0x00, 0x00)
         @test !haskey(c.in_flight, 0x0001)
+
+        c.in_flight[0x0002] = Future()
+
+        # Test unsuccessful ack
+        io = IOBuffer(UInt8[0x00, 0x01])
+        MQTTClient.handle_ack(c, io, 0x00, 0x00)
+        @test c.state === 0x03
     end
 
     @testset "handle_pubrec" begin
@@ -298,8 +372,9 @@ end
 
         # NOTE: update this to use different msg type.
         # # Set the ping_outstanding value to 0x0 and call the handle_pingresp function again
-        # c.ping_outstanding[] = 0x0
-        # MQTTClient.handle_pingresp(c, s, cmd, flags)
+        c.ping_outstanding[] = 0x0
+        @test_throws MethodError MQTTClient.handle_pingresp(c, s, cmd, flags)
+
         # p = take!(c.write_packets)
         # @test p == MQTTClient.Packet(MQTTClient.DISCONNECT, ())
     end

--- a/test/unittest.client.jl
+++ b/test/unittest.client.jl
@@ -108,7 +108,7 @@ end
         client, conn = MQTTClient.MakeConnection("localhost", 1883, client_id="foo")
         show(io, conn)
         str = take!(io) |> String
-        @test str == "MQTTConnection(Protocol: MQTTClient.TCP(ip\"::1\", 1883), Client ID: foo)"
+        @test contains(str, "MQTTConnection(Protocol: MQTTClient.TCP")
     end
 
     @testset "MQTT subscribe async" begin
@@ -285,6 +285,8 @@ end
 
         # Set the ping_outstanding value to 0x1
         c.ping_outstanding[] = 0x1
+
+        @atomicswap c.state = 0x01
 
         # Call the handle_pingresp function
         MQTTClient.handle_pingresp(c, s, cmd, flags)

--- a/test/unittest.utils.jl
+++ b/test/unittest.utils.jl
@@ -21,7 +21,7 @@ end;
 end
 
 @testset "mqtt distributed channel" begin
-    ch = MQTTClient.@mqtt_channel
+    ch = Channel{Packet}(typemax(Int64))
     a = MQTTClient.Packet(MQTTClient.PINGREQ, rand(UInt8, 16))
     put!(ch, a)
     b = take!(ch)


### PR DESCRIPTION
# Implement Disconnect functionality
_The primary effect of this PR is that calling disconnect will trigger all the mqtt processes to stop. This allows the MQTT client to be run on a thread without having dangling tasks on disconnect. as a byproduct states were implemented and error and connection handling was made more robust._

## Changes
- In `client.jl`, several changes have been made:
    - An atomic state variable has been added to the `Client` struct.
    - New fields `write_task`, `read_task`, and `keep_alive_task` have been added to the `Client` struct.
    - The constructor for the `Client` struct has been updated to initialize these new fields.
    - The functions `write_loop`, `read_loop`, and `keep_alive_loop` have been updated with new return types and modified control flow.
    - New functions for checking the state of the client (`isready`, `isconnected`, `isclosed`, and `iserror`) have been added.
    - The function `fetch` has been added to get the results of the tasks.
- In `src/handlers.jl`, atomic operations have been added to update the client state in various handler functions.
- In `src/interface.jl`, several changes have been made:
    - The function `connect_async` has been updated to initialize the client if it is not ready.
    - The tasks for writing, reading, and keeping alive are now stored in the client object.
    - The function `connect` now uses fetch instead of resolve on the future returned by connect_async.
    - The function disconnect has been updated to handle disconnection more robustly, including waiting for tasks to finish and updating the client state.
- In 'src/internals.jl', a dictionary mapping client states to symbols has been added.
- several tests have been updated.

## Impact

The changes should not impact the existing functionality, only enhancements to existing functionality. However, the addition of atomic operations are the first step in updating the Atomic fields aligning with the new standards in >1.7. The changes in `client.jl` provide new functionalities related to task management and state handling in the MQTT client. The changes in `handlers.jl` provide error handling and state management improvements. The changes in `interface.jl` provides improvements in connection management and error handling. The changes in `internals.jl` provide a clearer representation of client states. Changes in test files reflect updates in main code.

## Testing
Passes all unit tests and the "smoke" tests.
